### PR TITLE
Switch statamic settings file from default to user-controlled

### DIFF
--- a/recents.json
+++ b/recents.json
@@ -174,7 +174,7 @@
       {
          "projectType":"statamic",
          "nameRegex":"_site_name:\\s*(.*?)$",
-         "settingsFile":"_app/config/default.settings.yaml",
+         "settingsFile":"_config/settings.yaml",
          "image":"statamic.png",
          "keyFile":"statamic.php",
          "projectRootRelativeToKeyFile":"../../",


### PR DESCRIPTION
The `_app/config/default.settings.yaml` is a file that doesn't change and will always show the standard "Another Awesome Statamic Site" site name. This will use the user-controlled file so it will be up to date.
